### PR TITLE
fix xml parsing error

### DIFF
--- a/lib/cucumber_junit.js
+++ b/lib/cucumber_junit.js
@@ -98,7 +98,9 @@ module.exports = function (cucumberRaw) {
         cucumberJson.forEach(function (featureJson) {
             output = output.concat(convertFeature(featureJson));
         });
+        // wrap all <testsuite> elements in <testsuites> element
+        output = { testsuites: output };
     }
-
+    
     return xml(output, { indent: '    ' });
 };

--- a/tests/mocks/output.xml
+++ b/tests/mocks/output.xml
@@ -1,19 +1,21 @@
-<testsuite name="featureid;test-cucumber-junit" tests="6" failures="1" skipped="2">
-    <testcase name="Given a &quot;cucumber&quot; project" classname="featureid;test-cucumber-junit" time="5.678078312">
-    </testcase>
-    <testcase name="When I start the conversion" classname="featureid;test-cucumber-junit" time="0.547465333">
-    </testcase>
-    <testcase name="Then the conversion should be successful" classname="featureid;test-cucumber-junit" time="0.000100672">
-    </testcase>
-    <testcase name="And this should be undefined" classname="featureid;test-cucumber-junit">
-        <skipped message="">
-        </skipped>
-    </testcase>
-    <testcase name="And this should be skipped" classname="featureid;test-cucumber-junit">
-        <skipped message="">
-        </skipped>
-    </testcase>
-    <testcase name="And this should fail" classname="featureid;test-cucumber-junit" time="0.133006989">
-        <error message="AssertionError">AssertionError</error>
-    </testcase>
-</testsuite>
+<testsuites>
+    <testsuite name="featureid;test-cucumber-junit" tests="6" failures="1" skipped="2">
+        <testcase name="Given a &quot;cucumber&quot; project" classname="featureid;test-cucumber-junit" time="5.678078312">
+        </testcase>
+        <testcase name="When I start the conversion" classname="featureid;test-cucumber-junit" time="0.547465333">
+        </testcase>
+        <testcase name="Then the conversion should be successful" classname="featureid;test-cucumber-junit" time="0.000100672">
+        </testcase>
+        <testcase name="And this should be undefined" classname="featureid;test-cucumber-junit">
+            <skipped message="">
+            </skipped>
+        </testcase>
+        <testcase name="And this should be skipped" classname="featureid;test-cucumber-junit">
+            <skipped message="">
+            </skipped>
+        </testcase>
+        <testcase name="And this should fail" classname="featureid;test-cucumber-junit" time="0.133006989">
+            <error message="AssertionError">AssertionError</error>
+        </testcase>
+    </testsuite>
+</testsuites>


### PR DESCRIPTION
This is a fix for issue #1 that I sent before.
I just wrapped all `<testsuite>` elements in a `<testsuites>` element so that 
XML parsing will not throw an error anymore.
I also modified the output mock so that all tests will pass.
