### PR TITLE
Fixed a bug with background elements.

### DIFF
--- a/lib/cucumber_junit.js
+++ b/lib/cucumber_junit.js
@@ -91,9 +91,13 @@ function convertScenario (scenarioJson) {
  * @return {[type]}                   [description]
  */
 function convertFeature(featureJson) {
-    return featureJson.elements.map(function (scenarioJson) {
-        return convertScenario(scenarioJson);
-    });
+    return featureJson.elements
+        .filter(function(scenarioJson) {
+            return (scenarioJson.type !== 'background');
+        })
+        .map(function (scenarioJson) {
+            return convertScenario(scenarioJson);
+        });
 }
 
 /**

--- a/tests/mocks/input.json
+++ b/tests/mocks/input.json
@@ -3,6 +3,20 @@
     "id": "featureid",
     "elements": [
       {
+        "name": "",
+        "keyword": "Background",
+        "description": "",
+        "type": "background",
+        "line": 3,
+        "steps": [
+          {
+            "name": "a \"cucumber\" project",
+            "line": 34,
+            "keyword": "Given "
+          }
+        ]
+      },
+      {
         "id": "featureid;test-cucumber-junit",
         "steps": [
           {


### PR DESCRIPTION
Cucumber.js supports background steps that get prepended to every scenario.

```
Feature: foo
    Background:
        Given I do something first

    Scenario: bar
        Then something happens
```

The set of background steps are also included as an element in the JSON output, but the steps in it don't have a result property because they're not executed (yet). This makes cucumber-junit crash.

This fix filters out elements of type background. That's ok. The steps in the background are included in each scenario the steps run in (as you would expect), so nothing gets lost.

I also extended a test to cover this scenario.
