### PR TITLE
Add 'main' in package.json for easy requiring

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
   },
   "author": "St. John Johnson <st.john.johnson@gmail.com>",
   "license": "MIT",
+  "main": "./lib/cucumber_junit.js",
   "dependencies": {
     "xml": "0.0.12"
   },


### PR DESCRIPTION
Need to require this package in code to convert .json ouput into JUnit.