### PR TITLE
Fixed markup

### DIFF
--- a/lib/cucumber_junit.js
+++ b/lib/cucumber_junit.js
@@ -25,7 +25,7 @@ function convertStep (stepJson, scenarioJson) {
             break;
         case 'failed':
             stepOutput.push({
-                error: [
+                failure: [
                     {
                         _attr: {
                             message: stepJson.result.error_message.split("\n").shift()

--- a/lib/cucumber_junit.js
+++ b/lib/cucumber_junit.js
@@ -71,7 +71,7 @@ function convertScenario (scenarioJson) {
         scenarioJson.steps.forEach(function (stepJson) {
             var testcase = convertStep(stepJson, scenarioJson);
             // Check for errors and increment the failure rate
-            if (testcase[1] && testcase[1].error) {
+            if (testcase[1] && testcase[1].failure) {
                 scenarioOutput[0]._attr.failures += 1;
             }
             if (testcase[1] && testcase[1].skipped) {

--- a/lib/cucumber_junit.js
+++ b/lib/cucumber_junit.js
@@ -126,10 +126,7 @@ function cucumberJunit (cucumberRaw) {
     // wrap all <testsuite> elements in <testsuites> element
     return xml({ testsuites: output }, {
         indent: '    ',
-        declaration: {
-            standalone: 'yes',
-            encoding: 'UTF-8'
-        }
+        declaration: { encoding: 'UTF-8' }
     });
 };
 

--- a/lib/cucumber_junit.js
+++ b/lib/cucumber_junit.js
@@ -124,7 +124,13 @@ function cucumberJunit (cucumberRaw) {
     }
 
     // wrap all <testsuite> elements in <testsuites> element
-    return xml({ testsuites: output }, { indent: '    ' });
+    return xml({ testsuites: output }, {
+        indent: '    ',
+        declaration: {
+            standalone: 'yes',
+            encoding: 'UTF-8'
+        }
+    });
 };
 
 module.exports = cucumberJunit;

--- a/tests/cucumber_junit.test.js
+++ b/tests/cucumber_junit.test.js
@@ -28,10 +28,10 @@ Y.TestRunner.add(new Y.TestCase({
     },
 
     'conversion supports empty data': function () {
-        Assert.areEqual('<testsuites>\n</testsuites>', cucumber_junit(' ', { indent: '    ' }), 'No input JSON == Empty XML');
+        Assert.areEqual('<?xml version="1.0" encoding="UTF-8"?>\n<testsuites>\n</testsuites>', cucumber_junit(' ', { indent: '    ' }), 'No input JSON == Empty XML');
     },
 
     'conversion supports empty array': function () {
-        Assert.areEqual("<testsuites>\n    <testsuite>\n    </testsuite>\n</testsuites>", cucumber_junit('[]', { indent: '    ' }), 'Empty Array Json == Empty Testcase XML');
+        Assert.areEqual('<?xml version="1.0" encoding="UTF-8"?>\n<testsuites>\n    <testsuite>\n    </testsuite>\n</testsuites>', cucumber_junit('[]', { indent: '    ' }), 'Empty Array Json == Empty Testcase XML');
     }
 }));

--- a/tests/mocks/empty_output.xml
+++ b/tests/mocks/empty_output.xml
@@ -1,3 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
 <testsuites>
     <testsuite name="featureid;test-cucumber-junit" tests="0" failures="0" skipped="0">
     </testsuite>

--- a/tests/mocks/output.xml
+++ b/tests/mocks/output.xml
@@ -1,3 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
 <testsuites>
     <testsuite name="featureid;test-cucumber-junit" tests="6" failures="1" skipped="2">
         <testcase name="Given a &quot;cucumber&quot; project" classname="featureid;test-cucumber-junit" time="5.678078312">

--- a/tests/mocks/output.xml
+++ b/tests/mocks/output.xml
@@ -15,7 +15,7 @@
             </skipped>
         </testcase>
         <testcase name="And this should fail" classname="featureid;test-cucumber-junit" time="0.133006989">
-            <error message="AssertionError">AssertionError</error>
+            <failure message="AssertionError">AssertionError</failure>
         </testcase>
     </testsuite>
 </testsuites>


### PR DESCRIPTION
According to [JUnit Format specification](http://help.catchsoftware.com/display/ET/JUnit+Format), failed steps is marked with a `failure` tag, not an `error` tag.