### PR TITLE
added optional testsuite prefix

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ The following options are supported by `lib/cucumber_junit`:
 * indent - passed to the [XML formatter][XML], defaults to 4 spaces
 * stream - passed to the [XML formatter][XML] to return the result as a stream
 * declaration - passed to the [XML formatter][XML]
+* prefix - added to each test suite name (if test are executed against multiple browsers/devices)
 
 These options can be specified on the command line when calling `.bin/cucumber-junit`:
 
@@ -64,8 +65,14 @@ function cucumberXmlReport(opts) {
     var gutil = require('gulp-util'),
         through = require('through2'),
         cucumberJunit = require('cucumber-junit');
-
+    
     return through.obj(function (file, enc, cb) {
+        // If tests are executed against multiple browsers/devices
+        var suffix = file.path.match(/\/cucumber-?(.*)\.json/);
+        if (suffix) {
+            opts.prefix = suffix[1] + ';';
+        }
+        
         var xml = cucumberJunit(file.contents, opts);
         file.contents = new Buffer(xml);
         file.path = gutil.replaceExtension(file.path, '.xml');

--- a/lib/cucumber_junit.js
+++ b/lib/cucumber_junit.js
@@ -53,6 +53,10 @@ function convertStep (stepJson, scenarioJson, options) {
         }],
         result = stepJson.result || {};
 
+    if (options.prefix) {
+        stepOutput[0]._attr.name = options.prefix + stepOutput[0]._attr.name;
+    }
+
     if (result.duration) {
         // Convert from nanosecond to seconds
         stepOutput[0]._attr.time = result.duration / 1000000000;

--- a/lib/cucumber_junit.js
+++ b/lib/cucumber_junit.js
@@ -97,7 +97,8 @@ function convertStep (stepJson, scenarioJson, options) {
  *
  * @method convertScenario
  * @param  {Object}    scenarioJson Scenario output from Cucumber.JS
- * @param  {Object}    options      if `strict` is true, pending or undefined steps will be reported as failures
+ * @param  {Object}    options      if `strict` is true, pending or undefined steps will be reported as failures.
+ *                                  if `prefix` is provided, it will be added to the testsuite name.
  * @return {Array}                  Array of elements for an XML element <testsuite>
  */
 function convertScenario (scenarioJson, options) {
@@ -111,6 +112,10 @@ function convertScenario (scenarioJson, options) {
         }, {
             properties: []
         }];
+    if(options.prefix) {
+        scenarioOutput[0]._attr.name = options.prefix + scenarioOutput[0]._attr.name;
+    }
+
     if(scenarioJson.tags) {
         scenarioJson.tags.forEach(function (tagJson) {
             var tag = (typeof tagJson == "string" ? tagJson : tagJson.name);


### PR DESCRIPTION
I'm running all of my scenarios against multiple browsers, but currently I only see the report data for one of the browsers.  This PR fixes that.

Related: https://github.com/mattfritz/protractor-cucumber-framework/pull/25